### PR TITLE
%B, %*B, %*.*Bに簡易的に対応

### DIFF
--- a/build/test.txt
+++ b/build/test.txt
@@ -1,6 +1,0 @@
-[State ]
-type = DisplayToClipboard
-trigger1 = 1
-text = "%*B%hn%*B%hn"
-params = 64, 4931584, 65, 4931585
-ignorehitpause = 1


### PR DESCRIPTION
Fix #1.
%Bに部分的に対応、%.*Bや未知の仕様による不具合発生の可能性は残存。
少なくとも、例にあった用途であれば問題なくなったはず。